### PR TITLE
Add extensive Infrastructure unit tests

### DIFF
--- a/OpenAutomate.Infrastructure.Tests/Repositories/AssetRepositoryTests.cs
+++ b/OpenAutomate.Infrastructure.Tests/Repositories/AssetRepositoryTests.cs
@@ -1,4 +1,6 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Storage;
 using OpenAutomate.Core.Domain.Entities;
 using OpenAutomate.Core.Domain.IRepository;
 using OpenAutomate.Core.IServices;
@@ -51,13 +53,16 @@ namespace OpenAutomate.Infrastructure.Tests.Repositories
         }
 
 
+        private static readonly InMemoryDatabaseRoot _databaseRoot = new();
+
         private ApplicationDbContext GetInMemoryDbContext(string? dbName = null)
         {
             // Create a unique database name for each test if not provided
             dbName = dbName ?? Guid.NewGuid().ToString();
 
             var options = new DbContextOptionsBuilder<ApplicationDbContext>()
-                .UseInMemoryDatabase(databaseName: dbName)
+                .UseInMemoryDatabase(databaseName: dbName, _databaseRoot)
+                .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
                 .EnableSensitiveDataLogging()
                 .Options;
 

--- a/OpenAutomate.Infrastructure.Tests/Services/EmailTemplateServiceTests.cs
+++ b/OpenAutomate.Infrastructure.Tests/Services/EmailTemplateServiceTests.cs
@@ -1,0 +1,44 @@
+using OpenAutomate.Infrastructure.Services;
+using Xunit;
+
+namespace OpenAutomate.Infrastructure.Tests.Services
+{
+    public class EmailTemplateServiceTests
+    {
+        [Fact]
+        public async Task VerificationTemplate_IncludesUserNameAndLink()
+        {
+            var service = new EmailTemplateService();
+            string html = await service.GetVerificationEmailTemplateAsync("John", "https://example.com", 24);
+            Assert.Contains("John", html);
+            Assert.Contains("https://example.com", html);
+        }
+
+        [Fact]
+        public async Task WelcomeTemplate_IncludesLoginLink()
+        {
+            var service = new EmailTemplateService();
+            string html = await service.GetWelcomeEmailTemplateAsync("Jane", "https://example.com/login");
+            Assert.Contains("Jane", html);
+            Assert.Contains("https://example.com/login", html);
+        }
+
+        [Fact]
+        public async Task InvitationTemplate_IncludesOrganizationName()
+        {
+            var service = new EmailTemplateService();
+            string html = await service.GetInvitationEmailTemplateAsync("Bob", "Alice", "Org", "https://example.com/invite", 48, true);
+            Assert.Contains("Org", html);
+            Assert.Contains("https://example.com/invite", html);
+        }
+
+        [Fact]
+        public async Task ResetPasswordTemplate_IncludesResetLink()
+        {
+            var service = new EmailTemplateService();
+            string html = await service.GetResetPasswordEmailTemplateAsync("Sam", "https://example.com/reset", 4);
+            Assert.Contains("https://example.com/reset", html);
+            Assert.Contains("Sam", html);
+        }
+    }
+}

--- a/OpenAutomate.Infrastructure.Tests/Services/TenantContextTests.cs
+++ b/OpenAutomate.Infrastructure.Tests/Services/TenantContextTests.cs
@@ -1,0 +1,79 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using OpenAutomate.Core.Domain.Entities;
+using OpenAutomate.Core.Domain.IRepository;
+using OpenAutomate.Infrastructure.Services;
+using System;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OpenAutomate.Infrastructure.Tests.Services
+{
+    public class TenantContextTests
+    {
+        private ServiceProvider BuildProvider(Mock<IUnitOfWork> mockUow)
+        {
+            var services = new ServiceCollection();
+            services.AddScoped<IUnitOfWork>(_ => mockUow.Object);
+            return services.BuildServiceProvider();
+        }
+
+        [Fact]
+        public void SetAndClearTenant_UpdatesState()
+        {
+            var logger = Mock.Of<ILogger<TenantContext>>();
+            var context = new TenantContext(logger, new ServiceCollection().BuildServiceProvider());
+            var id = Guid.NewGuid();
+            context.SetTenant(id);
+            Assert.True(context.HasTenant);
+            Assert.Equal(id, context.CurrentTenantId);
+            context.ClearTenant();
+            Assert.False(context.HasTenant);
+            Assert.Throws<InvalidOperationException>(() => { var _ = context.CurrentTenantId; });
+        }
+
+        [Fact]
+        public async Task ResolveTenantFromSlugAsync_SetsTenantWhenFound()
+        {
+            var tenantId = Guid.NewGuid();
+            var repo = new Mock<IRepository<OrganizationUnit>>();
+            repo.Setup(r => r.GetFirstOrDefaultAsync(
+                    It.IsAny<Expression<Func<OrganizationUnit, bool>>>(),
+                    It.IsAny<Expression<Func<OrganizationUnit, object>>[]>()))
+                .ReturnsAsync(new OrganizationUnit { Id = tenantId, Name = "Test", Slug = "slug", IsActive = true });
+            var uow = new Mock<IUnitOfWork>();
+            uow.SetupGet(u => u.OrganizationUnits).Returns(repo.Object);
+            var provider = BuildProvider(uow);
+            var logger = Mock.Of<ILogger<TenantContext>>();
+            var context = new TenantContext(logger, provider);
+
+            var result = await context.ResolveTenantFromSlugAsync("slug");
+
+            Assert.True(result);
+            Assert.True(context.HasTenant);
+            Assert.Equal(tenantId, context.CurrentTenantId);
+        }
+
+        [Fact]
+        public async Task ResolveTenantFromSlugAsync_InvalidSlug_ReturnsFalse()
+        {
+            var repo = new Mock<IRepository<OrganizationUnit>>();
+            repo.Setup(r => r.GetFirstOrDefaultAsync(
+                    It.IsAny<Expression<Func<OrganizationUnit, bool>>>(),
+                    It.IsAny<Expression<Func<OrganizationUnit, object>>[]>()))
+                .ReturnsAsync((OrganizationUnit?)null);
+            var uow = new Mock<IUnitOfWork>();
+            uow.SetupGet(u => u.OrganizationUnits).Returns(repo.Object);
+            var provider = BuildProvider(uow);
+            var logger = Mock.Of<ILogger<TenantContext>>();
+            var context = new TenantContext(logger, provider);
+
+            var result = await context.ResolveTenantFromSlugAsync("missing");
+
+            Assert.False(result);
+            Assert.False(context.HasTenant);
+        }
+    }
+}

--- a/OpenAutomate.Infrastructure.Tests/Services/TenantQueryFilterServiceTests.cs
+++ b/OpenAutomate.Infrastructure.Tests/Services/TenantQueryFilterServiceTests.cs
@@ -1,0 +1,74 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Storage;
+using OpenAutomate.Core.Domain.Entities;
+using OpenAutomate.Core.IServices;
+using OpenAutomate.Infrastructure.DbContext;
+using OpenAutomate.Infrastructure.Services;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OpenAutomate.Infrastructure.Tests.Services
+{
+    public class TenantQueryFilterServiceTests
+    {
+        private class TestTenantContext : ITenantContext
+        {
+            public Guid CurrentTenantId { get; private set; }
+            public bool HasTenant { get; private set; }
+            public void SetTenant(Guid tenantId)
+            {
+                CurrentTenantId = tenantId;
+                HasTenant = true;
+            }
+            public void ClearTenant() { HasTenant = false; }
+            public Task<bool> ResolveTenantFromSlugAsync(string slug) => Task.FromResult(true);
+        }
+
+        private static readonly InMemoryDatabaseRoot _dbRoot = new();
+
+        private ApplicationDbContext CreateContext(TestTenantContext tenantContext, string? dbName = null)
+        {
+            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(dbName ?? Guid.NewGuid().ToString(), _dbRoot)
+                .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+                .EnableSensitiveDataLogging()
+                .Options;
+            return new ApplicationDbContext(options, tenantContext);
+        }
+
+        [Fact]
+        public async Task QueryFilter_WithTenant_ReturnsOnlyTenantEntities()
+        {
+            var tenantId = Guid.NewGuid();
+            var otherId = Guid.NewGuid();
+            var tenantContext = new TestTenantContext();
+            tenantContext.SetTenant(tenantId);
+            using var context = CreateContext(tenantContext);
+            context.Assets.Add(new Asset { Key = "a1", Value = "v1", OrganizationUnitId = tenantId });
+            context.Assets.Add(new Asset { Key = "a2", Value = "v2", OrganizationUnitId = otherId });
+            await context.SaveChangesAsync();
+
+            var assets = await context.Assets.ToListAsync();
+            Assert.Single(assets);
+            Assert.Equal(tenantId, assets[0].OrganizationUnitId);
+        }
+
+        [Fact]
+        public async Task QueryFilter_NoTenant_ReturnsAllEntities()
+        {
+            var tenantId = Guid.NewGuid();
+            var otherId = Guid.NewGuid();
+            var tenantContext = new TestTenantContext();
+            using var context = CreateContext(tenantContext);
+            context.Assets.Add(new Asset { Key = "a1", Value = "v1", OrganizationUnitId = tenantId });
+            context.Assets.Add(new Asset { Key = "a2", Value = "v2", OrganizationUnitId = otherId });
+            await context.SaveChangesAsync();
+
+            var assets = await context.Assets.ToListAsync();
+            Assert.Equal(2, assets.Count);
+        }
+    }
+}

--- a/OpenAutomate.Infrastructure.Tests/Utilities/SlugGeneratorTests.cs
+++ b/OpenAutomate.Infrastructure.Tests/Utilities/SlugGeneratorTests.cs
@@ -1,0 +1,44 @@
+using OpenAutomate.Infrastructure.Utilities;
+using Xunit;
+
+namespace OpenAutomate.Infrastructure.Tests.Utilities
+{
+    public class SlugGeneratorTests
+    {
+        [Fact]
+        public void GenerateSlug_RemovesAccentsAndInvalidCharacters()
+        {
+            var result = SlugGenerator.GenerateSlug("  Héllö Wörld!  ");
+            Assert.Equal("hello-world", result);
+        }
+
+        [Fact]
+        public void GenerateSlug_EmptyString_ReturnsEmpty()
+        {
+            var result = SlugGenerator.GenerateSlug(string.Empty);
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        public void EnsureUniqueSlug_ReturnsBaseWhenUnique()
+        {
+            string result = SlugGenerator.EnsureUniqueSlug("test", s => false);
+            Assert.Equal("test", result);
+        }
+
+        [Fact]
+        public void EnsureUniqueSlug_AppendsCounterWhenExists()
+        {
+            int calls = 0;
+            bool SlugExists(string slug)
+            {
+                calls++;
+                return slug == "test" || slug == "test-2";
+            }
+
+            string result = SlugGenerator.EnsureUniqueSlug("test", SlugExists);
+            Assert.Equal("test-3", result);
+            Assert.True(calls >= 2);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- cover slug generator utility
- test email template service helpers
- validate tenant context behaviors and slug resolution
- ensure tenant query filters restrict data appropriately
- suppress EF Core service provider warnings in tests

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: dotnet: command not found)*