### PR TITLE
Migrate scripts to use 'docker compose' command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
           fi
 
           # Install Docker Compose if not already installed
-          if ! command -v docker-compose &> /dev/null; then
+          if ! docker compose version &> /dev/null; then
             echo "Installing Docker Compose..."
             sudo apt-get update
             sudo apt-get install -y docker-compose-plugin
@@ -73,7 +73,7 @@ jobs:
           # Setup Redis if not already running
           if ! docker ps | grep -q openautomae-redis-prod; then
             echo "Setting up Redis..."
-            docker-compose -f docker-compose.redis.prod.yml up -d
+            docker compose -f docker-compose.redis.prod.yml up -d
           else
             echo "Redis already running"
           fi

--- a/setup-redis-ubuntu.sh
+++ b/setup-redis-ubuntu.sh
@@ -20,7 +20,7 @@ else
 fi
 
 # Install Docker Compose if not already installed
-if ! command -v docker-compose &> /dev/null; then
+if ! docker compose version &> /dev/null; then
     echo "🔧 Installing Docker Compose..."
     sudo apt-get update
     sudo apt-get install -y docker-compose-plugin
@@ -58,11 +58,11 @@ fi
 
 # Stop existing Redis containers if any
 echo "🛑 Stopping existing Redis containers..."
-docker-compose -f docker-compose.redis.prod.yml down || true
+docker compose -f docker-compose.redis.prod.yml down || true
 
 # Start Redis
 echo "🔄 Starting Redis..."
-docker-compose -f docker-compose.redis.prod.yml up -d
+docker compose -f docker-compose.redis.prod.yml up -d
 
 # Wait for Redis to be ready
 echo "⏳ Waiting for Redis to be ready..."
@@ -96,8 +96,8 @@ echo ""
 echo "🔧 Useful commands:"
 echo "   - Check Redis logs: docker logs openautomae-redis-prod"
 echo "   - Connect to Redis CLI: docker exec -it openautomae-redis-prod redis-cli"
-echo "   - Stop Redis: docker-compose -f docker-compose.redis.prod.yml down"
-echo "   - Restart Redis: docker-compose -f docker-compose.redis.prod.yml restart"
+echo "   - Stop Redis: docker compose -f docker-compose.redis.prod.yml down"
+echo "   - Restart Redis: docker compose -f docker-compose.redis.prod.yml restart"
 echo ""
 echo "🔄 You can now restart your OpenAutomate backend service:"
 echo "   sudo systemctl restart openautomate-backend"


### PR DESCRIPTION
Replaces deprecated 'docker-compose' CLI usage with the newer 'docker compose' subcommand in deployment workflow and Redis setup script. This ensures compatibility with recent Docker versions and aligns with best practices.