### PR TITLE
Refactor API response cache key and invalidation logic

### DIFF
--- a/OpenAutomate.API.Tests/ControllerTests/AssetControllerTests.cs
+++ b/OpenAutomate.API.Tests/ControllerTests/AssetControllerTests.cs
@@ -29,9 +29,7 @@ namespace OpenAutomate.API.Tests.ControllerTests
             
             _controller = new AssetController(
                 _mockAssetService.Object, 
-                _mockLogger.Object,
-                _mockCacheInvalidationService.Object,
-                _mockTenantContext.Object);
+                _mockLogger.Object);
             
             // Setup controller context
             var httpContext = new DefaultHttpContext();

--- a/OpenAutomate.API/Controllers/AssetController.cs
+++ b/OpenAutomate.API/Controllers/AssetController.cs
@@ -23,26 +23,18 @@ namespace OpenAutomate.API.Controllers
     {
         private readonly IAssetService _assetService;
         private readonly ILogger<AssetController> _logger;
-        private readonly ICacheInvalidationService _cacheInvalidationService;
-        private readonly ITenantContext _tenantContext;
         
         /// <summary>
         /// Initializes a new instance of the <see cref="AssetController"/> class
         /// </summary>
         /// <param name="assetService">The Asset service</param>
         /// <param name="logger">The logger</param>
-        /// <param name="cacheInvalidationService">The cache invalidation service</param>
-        /// <param name="tenantContext">The tenant context</param>
         public AssetController(
             IAssetService assetService, 
-            ILogger<AssetController> logger,
-            ICacheInvalidationService cacheInvalidationService,
-            ITenantContext tenantContext)
+            ILogger<AssetController> logger)
         {
             _assetService = assetService;
             _logger = logger;
-            _cacheInvalidationService = cacheInvalidationService;
-            _tenantContext = tenantContext;
         }
         
         /// <summary>
@@ -61,12 +53,6 @@ namespace OpenAutomate.API.Controllers
             try
             {
                 var asset = await _assetService.CreateAssetAsync(dto);
-                
-                // Invalidate assets cache
-                if (_tenantContext.HasTenant)
-                {
-                    await _cacheInvalidationService.InvalidateApiResponseCacheAsync("/odata/Assets", _tenantContext.CurrentTenantId);
-                }
                 
                 // Get the tenant from the route data
                 var tenant = RouteData.Values["tenant"]?.ToString();
@@ -185,12 +171,6 @@ namespace OpenAutomate.API.Controllers
             {
                 var asset = await _assetService.UpdateAssetAsync(id, dto);
                 
-                // Invalidate assets cache
-                if (_tenantContext.HasTenant)
-                {
-                    await _cacheInvalidationService.InvalidateApiResponseCacheAsync("/odata/Assets", _tenantContext.CurrentTenantId);
-                }
-                
                 return Ok(asset);
             }
             catch (KeyNotFoundException ex)
@@ -221,12 +201,6 @@ namespace OpenAutomate.API.Controllers
                 var deleted = await _assetService.DeleteAssetAsync(id);
                 if (!deleted)
                     return NotFound(new { message = $"Asset with ID {id} not found." });
-                
-                // Invalidate assets cache
-                if (_tenantContext.HasTenant)
-                {
-                    await _cacheInvalidationService.InvalidateApiResponseCacheAsync("/odata/Assets", _tenantContext.CurrentTenantId);
-                }
                     
                 return NoContent();
             }

--- a/OpenAutomate.API/Controllers/OData/AssetsController.cs
+++ b/OpenAutomate.API/Controllers/OData/AssetsController.cs
@@ -44,7 +44,6 @@ namespace OpenAutomate.API.Controllers.OData
         [HttpGet]
         [RequirePermission(Resources.AssetResource, Permissions.View)]
         [EnableQuery]
-        [EnableResponseCache(300)] // Cache for 5 minutes
         public async Task<IActionResult> Get()
         {
             try
@@ -71,7 +70,6 @@ namespace OpenAutomate.API.Controllers.OData
         [HttpGet("{key}")]
         [RequirePermission(Resources.AssetResource, Permissions.View)]
         [EnableQuery]
-        [EnableResponseCache(600)] // Cache for 10 minutes
         public async Task<IActionResult> Get([FromRoute] Guid key)
         {
             try

--- a/OpenAutomate.API/Controllers/OData/AuthoritiesController.cs
+++ b/OpenAutomate.API/Controllers/OData/AuthoritiesController.cs
@@ -58,7 +58,6 @@ namespace OpenAutomate.API.Controllers.OData
         [HttpGet]
         [RequirePermission(Resources.OrganizationUnitResource, Permissions.View)]
         [EnableQuery]
-        [EnableResponseCache(900)] // Cache for 15 minutes - authorities change less frequently
         public async Task<IActionResult> Get()
         {
             try
@@ -105,7 +104,6 @@ namespace OpenAutomate.API.Controllers.OData
         [HttpGet("{key}")]
         [RequirePermission(Resources.OrganizationUnitResource, Permissions.View)]
         [EnableQuery]
-        [EnableResponseCache(1800)] // Cache for 30 minutes - individual authorities are stable
         public async Task<IActionResult> Get([FromRoute] Guid key)
         {
             try

--- a/OpenAutomate.API/Controllers/OData/BotAgentsController.cs
+++ b/OpenAutomate.API/Controllers/OData/BotAgentsController.cs
@@ -56,7 +56,6 @@ namespace OpenAutomate.API.Controllers.OData
         [HttpGet]
         [RequirePermission(Resources.AgentResource, Permissions.View)]
         [EnableQuery]
-        [EnableResponseCache(180)] // Cache for 3 minutes - bot agents status changes more frequently
         public async Task<IActionResult> Get()
         {
             try
@@ -104,7 +103,6 @@ namespace OpenAutomate.API.Controllers.OData
         [HttpGet("{key}")]
         [RequirePermission(Resources.AgentResource, Permissions.View)]
         [EnableQuery]
-        [EnableResponseCache(300)] // Cache for 5 minutes
         public async Task<IActionResult> Get([FromRoute] Guid key)
         {
             try

--- a/OpenAutomate.Core.Tests/Utilities/CacheKeyUtilityTests.cs
+++ b/OpenAutomate.Core.Tests/Utilities/CacheKeyUtilityTests.cs
@@ -1,0 +1,124 @@
+using OpenAutomate.Core.Utilities;
+using Xunit;
+
+namespace OpenAutomate.Core.Tests.Utilities
+{
+    public class CacheKeyUtilityTests
+    {
+        [Fact]
+        public void GenerateApiResponseKey_Should_Create_Predictable_Prefix_With_Hash_Suffix()
+        {
+            // Arrange
+            var method = "GET";
+            var path = "/odata/Assets";
+            var queryString = "$filter=contains(Key,'test')&$orderby=Name asc";
+            var tenantId = "tenant-123";
+
+            // Act
+            var cacheKey = CacheKeyUtility.GenerateApiResponseKey(method, path, queryString, tenantId);
+
+            // Assert
+            var expectedPrefix = "api-cache:tenant-123:/odata/Assets:";
+            Assert.StartsWith(expectedPrefix, cacheKey);
+            Assert.True(cacheKey.Length > expectedPrefix.Length); // Should have hash after prefix
+        }
+
+        [Fact]
+        public void GenerateApiResponseKey_Should_Create_Different_Hashes_For_Different_Queries()
+        {
+            // Arrange
+            var method = "GET";
+            var path = "/odata/Assets";
+            var tenantId = "tenant-123";
+
+            // Act
+            var key1 = CacheKeyUtility.GenerateApiResponseKey(method, path, "$filter=contains(Key,'test')", tenantId);
+            var key2 = CacheKeyUtility.GenerateApiResponseKey(method, path, "$top=20&$skip=0", tenantId);
+
+            // Assert
+            var expectedPrefix = "api-cache:tenant-123:/odata/Assets:";
+            Assert.StartsWith(expectedPrefix, key1);
+            Assert.StartsWith(expectedPrefix, key2);
+            Assert.NotEqual(key1, key2); // Different queries should produce different hashes
+        }
+
+        [Fact]
+        public void GenerateApiResponseKey_Should_Create_Different_Keys_For_Different_Tenants()
+        {
+            // Arrange
+            var method = "GET";
+            var path = "/odata/Assets";
+            var queryString = "$filter=contains(Key,'test')";
+
+            // Act
+            var key1 = CacheKeyUtility.GenerateApiResponseKey(method, path, queryString, "tenant-123");
+            var key2 = CacheKeyUtility.GenerateApiResponseKey(method, path, queryString, "tenant-456");
+
+            // Assert
+            Assert.StartsWith("api-cache:tenant-123:/odata/Assets:", key1);
+            Assert.StartsWith("api-cache:tenant-456:/odata/Assets:", key2);
+            Assert.NotEqual(key1, key2);
+        }
+
+        [Fact]
+        public void GenerateApiResponsePattern_Should_Create_Correct_Wildcard_Pattern()
+        {
+            // Arrange
+            var basePath = "/odata/Assets";
+            var tenantId = "tenant-123";
+
+            // Act
+            var pattern = CacheKeyUtility.GenerateApiResponsePattern(basePath, tenantId);
+
+            // Assert
+            Assert.Equal("api-cache:tenant-123:/odata/Assets:*", pattern);
+        }
+
+        [Fact]
+        public void GenerateApiResponsePattern_Should_Handle_Path_With_Query_Parameters()
+        {
+            // Arrange
+            var pathWithQuery = "/odata/Assets?$filter=test";
+            var tenantId = "tenant-123";
+
+            // Act
+            var pattern = CacheKeyUtility.GenerateApiResponsePattern(pathWithQuery, tenantId);
+
+            // Assert
+            // Should strip query parameters and only use base path
+            Assert.Equal("api-cache:tenant-123:/odata/Assets:*", pattern);
+        }
+
+        [Fact]
+        public void GenerateApiResponsePattern_Should_Handle_Global_Tenant()
+        {
+            // Arrange
+            var basePath = "/odata/Assets";
+
+            // Act
+            var pattern = CacheKeyUtility.GenerateApiResponsePattern(basePath, null);
+
+            // Assert
+            Assert.Equal("api-cache:global:/odata/Assets:*", pattern);
+        }
+
+        [Fact]
+        public void Cache_Key_And_Pattern_Should_Be_Compatible()
+        {
+            // Arrange
+            var method = "GET";
+            var path = "/odata/Assets";
+            var queryString = "$filter=contains(Key,'test')&$orderby=Name asc";
+            var tenantId = "tenant-123";
+
+            // Act
+            var cacheKey = CacheKeyUtility.GenerateApiResponseKey(method, path, queryString, tenantId);
+            var pattern = CacheKeyUtility.GenerateApiResponsePattern(path, tenantId);
+
+            // Assert
+            // The cache key should match the pattern (if we replace * with anything)
+            var patternBase = pattern.Replace(":*", ":");
+            Assert.StartsWith(patternBase, cacheKey);
+        }
+    }
+}


### PR DESCRIPTION
Reworked cache key generation to use predictable prefixes and hashed suffixes, supporting additional parameters like user ID. Updated cache invalidation to use pattern-based removal for reliability and simplified AssetController by removing direct cache invalidation calls. Removed response cache attributes from OData controllers and added comprehensive unit tests for cache key utility.