### PR TITLE
Add customer portal endpoint and update plan naming

### DIFF
--- a/OpenAutomate.Core/Configurations/LemonSqueezySettings.cs
+++ b/OpenAutomate.Core/Configurations/LemonSqueezySettings.cs
@@ -26,9 +26,9 @@ public class LemonSqueezySettings
     public string ProductId { get; set; } = string.Empty;
 
     /// <summary>
-    /// Monthly variant ID for the Premium product
+    /// Pro plan variant ID for the Premium product
     /// </summary>
-    public string VariantId { get; set; } = string.Empty;
+    public string ProVariantId { get; set; } = string.Empty;
 
     /// <summary>
     /// Base URL for Lemon Squeezy API (default: https://api.lemonsqueezy.com/v1)
@@ -42,7 +42,13 @@ public class LemonSqueezySettings
 
     /// <summary>
     /// Trial period duration in minutes (default: 7 days = 10080 minutes)
-    /// For testing, set to smaller values like 5 minutes
+    /// Common values for testing:
+    /// - 2 minutes: 2
+    /// - 5 minutes: 5
+    /// - 30 minutes: 30
+    /// - 1 hour: 60
+    /// - 1 day: 1440
+    /// - 7 days: 10080
     /// </summary>
     public int TrialDurationMinutes { get; set; } = 10080; // 7 days default
 

--- a/OpenAutomate.Core/IServices/ISubscriptionService.cs
+++ b/OpenAutomate.Core/IServices/ISubscriptionService.cs
@@ -91,6 +91,13 @@ namespace OpenAutomate.Core.IServices
         /// <param name="organizationUnitId">The organization unit ID</param>
         /// <returns>True if any subscription was updated</returns>
         Task<bool> UpdateExpiredTrialStatusAsync(Guid organizationUnitId);
+
+        /// <summary>
+        /// Gets subscription by organization unit ID
+        /// </summary>
+        /// <param name="organizationUnitId">The organization unit ID</param>
+        /// <returns>The subscription or null if not found</returns>
+        Task<Subscription?> GetSubscriptionByOrganizationUnitIdAsync(Guid organizationUnitId);
     }
 
     /// <summary>

--- a/OpenAutomate.Infrastructure/Services/LemonsqueezyService.cs
+++ b/OpenAutomate.Infrastructure/Services/LemonsqueezyService.cs
@@ -93,7 +93,7 @@ namespace OpenAutomate.Infrastructure.Services
                                 data = new
                                 {
                                     type = "variants",
-                                    id = _settings.VariantId
+                                    id = _settings.ProVariantId
                                 }
                             }
                         }

--- a/OpenAutomate.Infrastructure/Services/OrganizationUnitService.cs
+++ b/OpenAutomate.Infrastructure/Services/OrganizationUnitService.cs
@@ -717,7 +717,7 @@ namespace OpenAutomate.Infrastructure.Services
             var subscription = new Core.Domain.Entities.Subscription
             {
                 OrganizationUnitId = organizationUnitId,
-                PlanName = "Premium", 
+                PlanName = "Pro", 
                 Status = "trialing",
                 TrialEndsAt = DateTime.UtcNow.AddMinutes(trialMinutes),
                 CreatedAt = DateTime.UtcNow,


### PR DESCRIPTION
Introduces a new API endpoint to retrieve the Lemon Squeezy customer portal URL for managing subscriptions. Updates plan naming from 'Premium' to 'Pro' across the codebase and refines LemonSqueezySettings to use 'ProVariantId'. Adds a service method to fetch subscriptions by organization unit ID and improves trial eligibility logic.