### PR TITLE
Enhance trial status logic and cache invalidation

### DIFF
--- a/OpenAutomate.API.Tests/ControllerTests/OrganizationUnitControllerTests.cs
+++ b/OpenAutomate.API.Tests/ControllerTests/OrganizationUnitControllerTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Moq;
 using OpenAutomate.API.Controllers;
 using OpenAutomate.Core.Domain.Entities;
@@ -17,16 +18,19 @@ namespace OpenAutomate.API.Tests.ControllerTests
     {
         private readonly Mock<IOrganizationUnitService> _mockOrgUnitService;
         private readonly Mock<ICacheInvalidationService> _mockCacheInvalidationService;
+        private readonly Mock<ILogger<OrganizationUnitController>> _mockLogger;
         private readonly OrganizationUnitController _controller;
 
         public OrganizationUnitControllerTests()
         {
             _mockOrgUnitService = new Mock<IOrganizationUnitService>();
             _mockCacheInvalidationService = new Mock<ICacheInvalidationService>();
+            _mockLogger = new Mock<ILogger<OrganizationUnitController>>();
             
             _controller = new OrganizationUnitController(
                 _mockOrgUnitService.Object,
-                _mockCacheInvalidationService.Object);
+                _mockCacheInvalidationService.Object,
+                _mockLogger.Object);
         }
 
         [Fact]


### PR DESCRIPTION
Refactored SubscriptionController to introduce a TrialStatus enum and a new method for determining user trial status, replacing the previous boolean eligibility check. Updated OrganizationUnitController to perform comprehensive cache invalidation and logging after creating a new organization unit, ensuring fresh trial status data is available. Adjusted related tests to support the new logger dependency.