### PR TITLE
Add system admin seeding service and configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -501,3 +501,4 @@ $RECYCLE.BIN/
 *.dotsettings.user
 *.resharper.user*
 **/appsettings.Development.json
+.claude/

--- a/OpenAutomate.API.Tests/ControllerTests/AuthControllerTests.cs
+++ b/OpenAutomate.API.Tests/ControllerTests/AuthControllerTests.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using Moq;
 using OpenAutomate.API.Controllers;
+using OpenAutomate.Core.Configurations;
 using OpenAutomate.Core.Dto.UserDto;
 using OpenAutomate.Core.Exceptions;
 using OpenAutomate.Core.IServices;
@@ -19,6 +21,7 @@ namespace OpenAutomate.API.Tests.ControllerTests
         private readonly Mock<IAuthService> _mockAuthService;
         private readonly Mock<ILogger<AuthController>> _mockLogger;
         private readonly Mock<ITenantContext> _mockTenantContext;
+        private readonly Mock<IOptions<AppSettings>> _mockAppSettings;
         private readonly AuthController _controller;
         private readonly Dictionary<string, string> _cookies;
         private readonly Mock<IRequestCookieCollection> _mockCookieCollection;
@@ -28,6 +31,20 @@ namespace OpenAutomate.API.Tests.ControllerTests
             _mockAuthService = new Mock<IAuthService>();
             _mockLogger = new Mock<ILogger<AuthController>>();
             _mockTenantContext = new Mock<ITenantContext>();
+            _mockAppSettings = new Mock<IOptions<AppSettings>>();
+            
+            // Setup AppSettings with default CookieSettings
+            var appSettings = new AppSettings
+            {
+                CookieSettings = new CookieSettings
+                {
+                    Domain = null,
+                    SameSite = "Lax", 
+                    Secure = false
+                }
+            };
+            _mockAppSettings.Setup(x => x.Value).Returns(appSettings);
+            
             _cookies = new Dictionary<string, string>();
 
             // Create mock cookie collection that reads from the dictionary
@@ -53,7 +70,8 @@ namespace OpenAutomate.API.Tests.ControllerTests
             _controller = new AuthController(
                 _mockAuthService.Object,
                 _mockLogger.Object,
-                _mockTenantContext.Object)
+                _mockTenantContext.Object,
+                _mockAppSettings.Object)
             {
                 ControllerContext = controllerContext
             };

--- a/OpenAutomate.API/Controllers/OData/ExecutionsController.cs
+++ b/OpenAutomate.API/Controllers/OData/ExecutionsController.cs
@@ -85,7 +85,7 @@ namespace OpenAutomate.API.Controllers.OData
                 }
 
                 var executions = await _executionService.GetAllExecutionsAsync();
-                
+
                 // Transform to DTOs for OData
                 var executionDtos = executions.Select(execution => new ExecutionResponseDto
                 {

--- a/OpenAutomate.API/Program.cs
+++ b/OpenAutomate.API/Program.cs
@@ -74,6 +74,7 @@ namespace OpenAutomate.API
             builder.Services.Configure<RedisCacheConfiguration>(appSettingsSection.GetSection("RedisCache"));
             builder.Services.Configure<EmailSettings>(appSettingsSection.GetSection("EmailSettings"));
             builder.Services.Configure<LemonSqueezySettings>(appSettingsSection.GetSection("LemonSqueezy"));
+            builder.Services.Configure<AdminSeedSettings>(appSettingsSection.GetSection("AdminSeed"));
         }
         
         private static void ConfigureLogging(WebApplicationBuilder builder)
@@ -312,6 +313,9 @@ namespace OpenAutomate.API
 
             // Register system statistics service
             builder.Services.AddScoped<ISystemStatisticsService, SystemStatisticsService>();
+            
+            // Register admin seeding service
+            builder.Services.AddScoped<IAdminSeedService, AdminSeedService>();
         }
         
         private static void ConfigureAuthentication(WebApplicationBuilder builder)
@@ -546,6 +550,25 @@ namespace OpenAutomate.API
                 catch (Exception ex)
                 {
                     Console.WriteLine($"An error occurred ensuring Quartz.NET schema: {ex.Message}");
+                }
+
+                // Seed system administrator account
+                var adminSeedService = scope.ServiceProvider.GetRequiredService<IAdminSeedService>();
+                try
+                {
+                    var adminSeeded = await adminSeedService.SeedSystemAdminAsync();
+                    if (adminSeeded)
+                    {
+                        Console.WriteLine("System administrator account seeded successfully.");
+                    }
+                    else
+                    {
+                        Console.WriteLine("System administrator account already exists or seeding is disabled.");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"An error occurred seeding system admin: {ex.Message}");
                 }
             }
         }

--- a/OpenAutomate.API/appsettings.json
+++ b/OpenAutomate.API/appsettings.json
@@ -76,6 +76,11 @@
     "Cors": {
       "AllowedOrigins": [ "https://openautomate.io", "https://cloud.openautomate.io", "https://api.openautomate.io" ]
     },
+    "CookieSettings": {
+      "Domain": ".openautomate.io",
+      "SameSite": "None",
+      "Secure": true
+    },
     "EmailSettings": {
       "SmtpServer": "email-smtp.ap-southeast-1.amazonaws.com",
       "Port": 2587,
@@ -109,6 +114,13 @@
     "Subscription": {
       "EnforceSubscriptions": true,
       "DefaultPlanName": "Pro"
+    },
+    "AdminSeed": {
+      "Email": "PLACEHOLDER_WILL_BE_OVERRIDDEN_BY_ENV_VAR",
+      "Password": "PLACEHOLDER_WILL_BE_OVERRIDDEN_BY_ENV_VAR",
+      "FirstName": "System",
+      "LastName": "Administrator",
+      "EnableSeeding": false
     }
   }
 }

--- a/OpenAutomate.Core/Configurations/AdminSeedSettings.cs
+++ b/OpenAutomate.Core/Configurations/AdminSeedSettings.cs
@@ -1,0 +1,32 @@
+namespace OpenAutomate.Core.Configurations;
+
+/// <summary>
+/// Configuration settings for seeding the initial system administrator account
+/// </summary>
+public class AdminSeedSettings
+{
+    /// <summary>
+    /// Email address for the system administrator account
+    /// </summary>
+    public string Email { get; set; } = "admin@openautomate.io";
+    
+    /// <summary>
+    /// Password for the system administrator account
+    /// </summary>
+    public string Password { get; set; } = "openAutomate@12345";
+    
+    /// <summary>
+    /// First name for the system administrator account
+    /// </summary>
+    public string FirstName { get; set; } = "System";
+    
+    /// <summary>
+    /// Last name for the system administrator account
+    /// </summary>
+    public string LastName { get; set; } = "Administrator";
+    
+    /// <summary>
+    /// Whether to enable automatic seeding of admin account on startup
+    /// </summary>
+    public bool EnableSeeding { get; set; } = true;
+}

--- a/OpenAutomate.Core/Configurations/AppSettings.cs
+++ b/OpenAutomate.Core/Configurations/AppSettings.cs
@@ -9,6 +9,8 @@ public class AppSettings
     public JwtSettings Jwt { get; set; } = new JwtSettings();
     public DatabaseSettings Database { get; set; } = new DatabaseSettings();
     public CorsSettings Cors { get; set; } = new CorsSettings();
+    public CookieSettings CookieSettings { get; set; } = new CookieSettings();
     public RedisSettings Redis { get; set; } = new RedisSettings();
     public LemonSqueezySettings LemonSqueezy { get; set; } = new LemonSqueezySettings();
+    public AdminSeedSettings AdminSeed { get; set; } = new AdminSeedSettings();
 } 

--- a/OpenAutomate.Core/Configurations/CookieSettings.cs
+++ b/OpenAutomate.Core/Configurations/CookieSettings.cs
@@ -1,0 +1,22 @@
+namespace OpenAutomate.Core.Configurations;
+
+/// <summary>
+/// Settings for cookie configuration
+/// </summary>
+public class CookieSettings
+{
+    /// <summary>
+    /// Cookie domain for cross-subdomain access
+    /// </summary>
+    public string? Domain { get; set; }
+    
+    /// <summary>
+    /// SameSite cookie attribute
+    /// </summary>
+    public string SameSite { get; set; } = "None";
+    
+    /// <summary>
+    /// Whether cookies should be secure (HTTPS only)
+    /// </summary>
+    public bool Secure { get; set; } = true;
+}

--- a/OpenAutomate.Core/IServices/IAdminSeedService.cs
+++ b/OpenAutomate.Core/IServices/IAdminSeedService.cs
@@ -1,0 +1,13 @@
+namespace OpenAutomate.Core.IServices;
+
+/// <summary>
+/// Service for seeding the initial system administrator account
+/// </summary>
+public interface IAdminSeedService
+{
+    /// <summary>
+    /// Seeds the system administrator account if it doesn't exist and seeding is enabled
+    /// </summary>
+    /// <returns>True if admin was seeded, false if already exists or seeding is disabled</returns>
+    Task<bool> SeedSystemAdminAsync();
+}

--- a/OpenAutomate.Infrastructure.Tests/ServiceTests/AdminSeedServiceTests.cs
+++ b/OpenAutomate.Infrastructure.Tests/ServiceTests/AdminSeedServiceTests.cs
@@ -14,7 +14,7 @@ namespace OpenAutomate.Infrastructure.Tests.ServiceTests;
 public class AdminSeedServiceTests
 {
     private readonly Mock<IUnitOfWork> _mockUnitOfWork;
-    private readonly Mock<IUserRepository> _mockUserRepository;
+    private readonly Mock<IRepository<User>> _mockUserRepository;
     private readonly Mock<ILogger<AdminSeedService>> _mockLogger;
     private readonly Mock<IOptions<AdminSeedSettings>> _mockOptions;
     private readonly AdminSeedService _adminSeedService;
@@ -23,7 +23,7 @@ public class AdminSeedServiceTests
     public AdminSeedServiceTests()
     {
         _mockUnitOfWork = new Mock<IUnitOfWork>();
-        _mockUserRepository = new Mock<IUserRepository>();
+        _mockUserRepository = new Mock<IRepository<User>>();
         _mockLogger = new Mock<ILogger<AdminSeedService>>();
         _mockOptions = new Mock<IOptions<AdminSeedSettings>>();
 

--- a/OpenAutomate.Infrastructure.Tests/ServiceTests/AdminSeedServiceTests.cs
+++ b/OpenAutomate.Infrastructure.Tests/ServiceTests/AdminSeedServiceTests.cs
@@ -1,0 +1,111 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using OpenAutomate.Core.Configurations;
+using OpenAutomate.Core.Domain.Entities;
+using OpenAutomate.Core.Domain.Enums;
+using OpenAutomate.Core.Domain.IRepository;
+using OpenAutomate.Infrastructure.Services;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace OpenAutomate.Infrastructure.Tests.ServiceTests;
+
+public class AdminSeedServiceTests
+{
+    private readonly Mock<IUnitOfWork> _mockUnitOfWork;
+    private readonly Mock<IUserRepository> _mockUserRepository;
+    private readonly Mock<ILogger<AdminSeedService>> _mockLogger;
+    private readonly Mock<IOptions<AdminSeedSettings>> _mockOptions;
+    private readonly AdminSeedService _adminSeedService;
+    private readonly AdminSeedSettings _adminSeedSettings;
+
+    public AdminSeedServiceTests()
+    {
+        _mockUnitOfWork = new Mock<IUnitOfWork>();
+        _mockUserRepository = new Mock<IUserRepository>();
+        _mockLogger = new Mock<ILogger<AdminSeedService>>();
+        _mockOptions = new Mock<IOptions<AdminSeedSettings>>();
+
+        _adminSeedSettings = new AdminSeedSettings
+        {
+            Email = "admin@test.com",
+            Password = "testPassword123",
+            FirstName = "Test",
+            LastName = "Admin",
+            EnableSeeding = true
+        };
+
+        _mockOptions.Setup(x => x.Value).Returns(_adminSeedSettings);
+        _mockUnitOfWork.Setup(x => x.Users).Returns(_mockUserRepository.Object);
+
+        _adminSeedService = new AdminSeedService(_mockUnitOfWork.Object, _mockLogger.Object, _mockOptions.Object);
+    }
+
+    [Fact]
+    public async Task SeedSystemAdminAsync_WhenSeedingDisabled_ReturnsFalse()
+    {
+        // Arrange
+        _adminSeedSettings.EnableSeeding = false;
+
+        // Act
+        var result = await _adminSeedService.SeedSystemAdminAsync();
+
+        // Assert
+        Assert.False(result);
+        _mockUserRepository.Verify(x => x.GetFirstOrDefaultAsync(It.IsAny<Expression<Func<User, bool>>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SeedSystemAdminAsync_WhenAdminExists_ReturnsFalse()
+    {
+        // Arrange
+        var existingUser = new User { Email = _adminSeedSettings.Email };
+        _mockUserRepository.Setup(x => x.GetFirstOrDefaultAsync(It.IsAny<Expression<Func<User, bool>>>()))
+                          .ReturnsAsync(existingUser);
+
+        // Act
+        var result = await _adminSeedService.SeedSystemAdminAsync();
+
+        // Assert
+        Assert.False(result);
+        _mockUserRepository.Verify(x => x.AddAsync(It.IsAny<User>()), Times.Never);
+        _mockUnitOfWork.Verify(x => x.CompleteAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task SeedSystemAdminAsync_WhenAdminDoesNotExist_CreatesAdminAndReturnsTrue()
+    {
+        // Arrange
+        _mockUserRepository.Setup(x => x.GetFirstOrDefaultAsync(It.IsAny<Expression<Func<User, bool>>>()))
+                          .ReturnsAsync((User?)null);
+        _mockUnitOfWork.Setup(x => x.CompleteAsync()).ReturnsAsync(1);
+
+        // Act
+        var result = await _adminSeedService.SeedSystemAdminAsync();
+
+        // Assert
+        Assert.True(result);
+        _mockUserRepository.Verify(x => x.AddAsync(It.Is<User>(u => 
+            u.Email == _adminSeedSettings.Email &&
+            u.FirstName == _adminSeedSettings.FirstName &&
+            u.LastName == _adminSeedSettings.LastName &&
+            u.SystemRole == SystemRole.Admin &&
+            u.IsEmailVerified == true &&
+            !string.IsNullOrEmpty(u.PasswordHash) &&
+            !string.IsNullOrEmpty(u.PasswordSalt)
+        )), Times.Once);
+        _mockUnitOfWork.Verify(x => x.CompleteAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task SeedSystemAdminAsync_WhenExceptionThrown_RethrowsException()
+    {
+        // Arrange
+        _mockUserRepository.Setup(x => x.GetFirstOrDefaultAsync(It.IsAny<Expression<Func<User, bool>>>()))
+                          .ThrowsAsync(new Exception("Database error"));
+
+        // Act & Assert
+        await Assert.ThrowsAsync<Exception>(() => _adminSeedService.SeedSystemAdminAsync());
+    }
+}

--- a/OpenAutomate.Infrastructure/Services/AdminSeedService.cs
+++ b/OpenAutomate.Infrastructure/Services/AdminSeedService.cs
@@ -1,0 +1,103 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OpenAutomate.Core.Configurations;
+using OpenAutomate.Core.Domain.Entities;
+using OpenAutomate.Core.Domain.Enums;
+using OpenAutomate.Core.Domain.IRepository;
+using OpenAutomate.Core.IServices;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace OpenAutomate.Infrastructure.Services;
+
+/// <summary>
+/// Service for seeding the initial system administrator account
+/// </summary>
+public class AdminSeedService : IAdminSeedService
+{
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<AdminSeedService> _logger;
+    private readonly AdminSeedSettings _adminSeedSettings;
+
+    public AdminSeedService(
+        IUnitOfWork unitOfWork,
+        ILogger<AdminSeedService> logger,
+        IOptions<AdminSeedSettings> adminSeedSettings)
+    {
+        _unitOfWork = unitOfWork;
+        _logger = logger;
+        _adminSeedSettings = adminSeedSettings.Value;
+    }
+
+    /// <summary>
+    /// Seeds the system administrator account if it doesn't exist and seeding is enabled
+    /// </summary>
+    /// <returns>True if admin was seeded, false if already exists or seeding is disabled</returns>
+    public async Task<bool> SeedSystemAdminAsync()
+    {
+        try
+        {
+            // Check if seeding is enabled
+            if (!_adminSeedSettings.EnableSeeding)
+            {
+                _logger.LogInformation("Admin seeding is disabled");
+                return false;
+            }
+
+            // Check if system admin already exists
+            var existingAdmin = await _unitOfWork.Users.GetFirstOrDefaultAsync(
+                u => u.Email != null && u.Email.ToLower() == _adminSeedSettings.Email.ToLower());
+
+            if (existingAdmin != null)
+            {
+                _logger.LogInformation("System admin account already exists with email: {Email}", _adminSeedSettings.Email);
+                return false;
+            }
+
+            // Create password hash
+            CreatePasswordHash(_adminSeedSettings.Password, out string passwordHash, out string passwordSalt);
+
+            // Create new system admin user
+            var adminUser = new User
+            {
+                Id = Guid.NewGuid(),
+                Email = _adminSeedSettings.Email,
+                FirstName = _adminSeedSettings.FirstName,
+                LastName = _adminSeedSettings.LastName,
+                PasswordHash = passwordHash,
+                PasswordSalt = passwordSalt,
+                SystemRole = SystemRole.Admin,
+                IsEmailVerified = true, // Admin account should be pre-verified
+                CreatedAt = DateTime.UtcNow,
+                CreatedBy = null // System seeded account
+            };
+
+            // Add user to database
+            await _unitOfWork.Users.AddAsync(adminUser);
+            await _unitOfWork.CompleteAsync();
+
+            _logger.LogInformation("System admin account created successfully with email: {Email}", _adminSeedSettings.Email);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error occurred while seeding system admin account");
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Creates password hash and salt using HMACSHA512
+    /// </summary>
+    /// <param name="password">Plain text password</param>
+    /// <param name="passwordHash">Output password hash</param>
+    /// <param name="passwordSalt">Output password salt</param>
+    private static void CreatePasswordHash(string password, out string passwordHash, out string passwordSalt)
+    {
+        using var hmac = new HMACSHA512();
+        byte[] saltBytes = hmac.Key;
+        byte[] hashBytes = hmac.ComputeHash(Encoding.UTF8.GetBytes(password));
+        passwordSalt = Convert.ToBase64String(saltBytes);
+        passwordHash = Convert.ToBase64String(hashBytes);
+    }
+}

--- a/OpenAutomate.Infrastructure/Services/ExecutionService.cs
+++ b/OpenAutomate.Infrastructure/Services/ExecutionService.cs
@@ -42,9 +42,9 @@ namespace OpenAutomate.Infrastructure.Services
             {
                 throw new InvalidOperationException(TenantNotAvailableMessage);
             }
-            
+
             var currentTenantId = _tenantContext.CurrentTenantId;
-            
+
             var execution = new Execution
             {
                 BotAgentId = dto.BotAgentId,
@@ -57,8 +57,8 @@ namespace OpenAutomate.Infrastructure.Services
             await _unitOfWork.Executions.AddAsync(execution);
             await _unitOfWork.CompleteAsync();
 
-            _logger.LogInformation("Execution created: {ExecutionId}, BotAgent: {BotAgentId}, Package: {PackageId}",
-                execution.Id, dto.BotAgentId, dto.PackageId);
+            _logger.LogInformation("Execution created: {ExecutionId} - Status: {Status} - BotAgent: {BotAgentId} - Package: {PackageId} - Tenant: {TenantId}",
+                execution.Id.ToString().Substring(0, 8), execution.Status, dto.BotAgentId, dto.PackageId, currentTenantId);
 
             return execution;
         }        /// <summary>
@@ -91,9 +91,9 @@ namespace OpenAutomate.Infrastructure.Services
             {
                 throw new InvalidOperationException(TenantNotAvailableMessage);
             }
-            
+
             var currentTenantId = _tenantContext.CurrentTenantId;
-            
+
             var executions = await _unitOfWork.Executions.GetAllAsync(
                 e => e.OrganizationUnitId == currentTenantId,
                 null,
@@ -132,9 +132,11 @@ namespace OpenAutomate.Infrastructure.Services
             var execution = await GetExecutionByIdAsync(id);
             if (execution == null)
             {
+                _logger.LogWarning("UpdateExecutionStatusAsync: Execution {ExecutionId} not found", id);
                 return null;
             }
 
+            var oldStatus = execution.Status;
             execution.Status = status;
             execution.ErrorMessage = errorMessage;
             execution.LogOutput = logOutput;
@@ -149,8 +151,8 @@ namespace OpenAutomate.Infrastructure.Services
 
             await _unitOfWork.CompleteAsync();
 
-            _logger.LogInformation("Execution status updated: {ExecutionId}, Status: {Status}",
-                execution.Id, status);
+            _logger.LogInformation("Execution status updated: {ExecutionId} - {OldStatus} -> {NewStatus}",
+                execution.Id.ToString().Substring(0, 8), oldStatus, status);
 
             return execution;
         }


### PR DESCRIPTION
Introduces AdminSeedSettings and IAdminSeedService for seeding a system administrator account on startup. Implements AdminSeedService with password hashing, integrates it into API startup, and adds related configuration to appsettings.json. Includes unit tests for the seeding logic. Also improves logging in ExecutionService and updates .gitignore.