### PR TITLE
Add HasLogs property to execution DTOs

### DIFF
--- a/OpenAutomate.API/Controllers/OData/ExecutionsController.cs
+++ b/OpenAutomate.API/Controllers/OData/ExecutionsController.cs
@@ -97,6 +97,7 @@ namespace OpenAutomate.API.Controllers.OData
                     EndTime = execution.EndTime,
                     ErrorMessage = execution.ErrorMessage,
                     LogOutput = execution.LogOutput,
+                    HasLogs = !string.IsNullOrEmpty(execution.LogS3Path),
                     BotAgentName = execution.BotAgent?.Name,
                     PackageName = execution.Package?.Name,
                     PackageVersion = execution.Package?.Versions?.FirstOrDefault()?.VersionNumber
@@ -164,6 +165,7 @@ namespace OpenAutomate.API.Controllers.OData
                     EndTime = execution.EndTime,
                     ErrorMessage = execution.ErrorMessage,
                     LogOutput = execution.LogOutput,
+                    HasLogs = !string.IsNullOrEmpty(execution.LogS3Path),
                     BotAgentName = execution.BotAgent?.Name,
                     PackageName = execution.Package?.Name,
                     PackageVersion = execution.Package?.Versions?.FirstOrDefault()?.VersionNumber


### PR DESCRIPTION
Introduces a HasLogs property to indicate if LogS3Path is present in execution DTOs returned by the controller.