### PR TITLE
Return sensitive fields only on bot agent creation/regeneration

### DIFF
--- a/OpenAutomate.Core/Dto/BotAgent/BotAgentResponseDto.cs
+++ b/OpenAutomate.Core/Dto/BotAgent/BotAgentResponseDto.cs
@@ -23,17 +23,17 @@ namespace OpenAutomate.Core.Dto.BotAgent
         public string MachineName { get; set; }
         
         /// <summary>
-        /// The machine key used for authentication (only returned once during creation)
+        /// The machine key used for authentication (only returned during creation/regeneration)
         /// </summary>
-        public string MachineKey { get; set; }
-        
+        public string? MachineKey { get; set; }
+
         /// <summary>
         /// Current status of the Bot Agent (Pending, Online, Offline, etc.)
         /// </summary>
         public string Status { get; set; }
-        
+
         /// <summary>
-        /// Timestamp of the last successful connection from this Bot Agent
+        /// Timestamp of the last successful connection from this Bot Agent (excluded from general responses)
         /// </summary>
         public DateTime? LastConnected { get; set; }
         

--- a/OpenAutomate.Infrastructure/Services/BotAgentService.cs
+++ b/OpenAutomate.Infrastructure/Services/BotAgentService.cs
@@ -64,10 +64,10 @@ namespace OpenAutomate.Infrastructure.Services
             await _unitOfWork.BotAgents.AddAsync(botAgent);
             await _unitOfWork.CompleteAsync();
             
-            _logger.LogInformation("Bot Agent created: {BotAgentId}, Name: {Name}, Machine: {MachineName}", 
+            _logger.LogInformation("Bot Agent created: {BotAgentId}, Name: {Name}, Machine: {MachineName}",
                 botAgent.Id, botAgent.Name, botAgent.MachineName);
-                
-            return MapToResponseDto(botAgent);
+
+            return MapToResponseDtoWithSensitiveFields(botAgent);
         }
         
         /// <inheritdoc />
@@ -108,8 +108,8 @@ namespace OpenAutomate.Infrastructure.Services
             await _unitOfWork.CompleteAsync();
             
             _logger.LogInformation("Machine key regenerated for Bot Agent: {BotAgentId}", botAgent.Id);
-            
-            return MapToResponseDto(botAgent);
+
+            return MapToResponseDtoWithSensitiveFields(botAgent);
         }
 
         /// <inheritdoc />
@@ -147,11 +147,30 @@ namespace OpenAutomate.Infrastructure.Services
         }
         
         /// <summary>
-        /// Maps a BotAgent entity to a BotAgentResponseDto
+        /// Maps a BotAgent entity to a BotAgentResponseDto (excludes sensitive fields)
         /// </summary>
         /// <param name="botAgent">The Bot Agent entity</param>
-        /// <returns>DTO representation of the Bot Agent</returns>
+        /// <returns>DTO representation of the Bot Agent without sensitive fields</returns>
         private BotAgentResponseDto MapToResponseDto(BotAgent botAgent)
+        {
+            return new BotAgentResponseDto
+            {
+                Id = botAgent.Id,
+                Name = botAgent.Name,
+                MachineName = botAgent.MachineName,
+                MachineKey = null, // Excluded for security
+                Status = botAgent.Status,
+                LastConnected = null, // Excluded per user request
+                IsActive = botAgent.IsActive
+            };
+        }
+
+        /// <summary>
+        /// Maps a BotAgent entity to a BotAgentResponseDto including sensitive fields (for creation/regeneration)
+        /// </summary>
+        /// <param name="botAgent">The Bot Agent entity</param>
+        /// <returns>DTO representation of the Bot Agent with all fields</returns>
+        private BotAgentResponseDto MapToResponseDtoWithSensitiveFields(BotAgent botAgent)
         {
             return new BotAgentResponseDto
             {


### PR DESCRIPTION
Updated BotAgentResponseDto and BotAgentService to ensure sensitive fields like MachineKey and LastConnected are only included in responses during bot agent creation or key regeneration. General responses now exclude these fields for improved security.