### PR TITLE
Add timezone diagnostic endpoint and improve timezone resolution

### DIFF
--- a/OpenAutomate.Core/OpenAutomate.Core.csproj
+++ b/OpenAutomate.Core/OpenAutomate.Core.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="CsvHelper" Version="33.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.2" />
+    <PackageReference Include="TimeZoneConverter" Version="6.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Introduces a new /timezone-test/{timeZoneId} endpoint in ScheduleController for testing timezone resolution and cron calculations. Enhances DateTimeUtility.GetTimeZoneInfo to support IANA and Windows timezone IDs using the TimeZoneConverter package, with additional manual mapping and improved error handling. Adds TimeZoneConverter as a dependency in the core project.