### PR TITLE
Refactor BotAgent OData to use non-sensitive DTO

### DIFF
--- a/OpenAutomate.API/Attributes/RequirePermissionAttribute.cs
+++ b/OpenAutomate.API/Attributes/RequirePermissionAttribute.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using OpenAutomate.Core.Domain.Entities;
 using OpenAutomate.Core.Domain.Enums;
 using OpenAutomate.Core.IServices;
+using OpenAutomate.Core.Constants;
 using System;
 using System.Security.Claims;
 using System.Threading.Tasks;
@@ -62,11 +63,37 @@ namespace OpenAutomate.API.Attributes
             
             if (!hasPermission)
             {
-                context.Result = new ForbidResult();
+                var permissionName = GetPermissionName(_permission);
+                var resourceDisplayName = Resources.GetDisplayName(_resourceName);
+
+                var errorMessage = $"Access denied. You need '{permissionName}' permission for '{resourceDisplayName}' to perform this action.";
+
+                context.Result = new ObjectResult(new { message = errorMessage })
+                {
+                    StatusCode = 403
+                };
                 return;
             }
             
             await next();
         }
+
+        /// <summary>
+        /// Gets the human-readable name for a permission level
+        /// </summary>
+        /// <param name="permission">The permission level</param>
+        /// <returns>Human-readable permission name</returns>
+        private static string GetPermissionName(int permission)
+        {
+            return permission switch
+            {
+                Permissions.NoAccess => "No Access",
+                Permissions.View => "View",
+                Permissions.Create => "Create",
+                Permissions.Update => "Update",
+                Permissions.Delete => "Full Access",
+                _ => $"Permission Level {permission}"
+            };
+        }
     }
-} 
+}

--- a/OpenAutomate.API/Controllers/AuthorController.cs
+++ b/OpenAutomate.API/Controllers/AuthorController.cs
@@ -19,7 +19,7 @@ namespace OpenAutomate.API.Controllers
     /// <remarks>
     /// Provides endpoints for creating roles, assigning permissions, and managing user authorities.
     /// All operations are scoped to the current organization unit (tenant).
-    /// Permission levels: 0=No Access, 1=View, 2=Create, 3=Update (includes Execute), 4=Delete/Full Admin
+    /// Permission levels: 0=No Access, 1=View, 2=Create, 3=Update, 4=Delete/Full Admin
     /// </remarks>
     [ApiController]
     [Route("{tenant}/api/author")]

--- a/OpenAutomate.API/Controllers/OData/BotAgentsController.cs
+++ b/OpenAutomate.API/Controllers/OData/BotAgentsController.cs
@@ -82,7 +82,8 @@ namespace OpenAutomate.API.Controllers.OData
                 }
                 
                 var botAgents = await _botAgentService.GetAllBotAgentsAsync();
-                return Ok(botAgents);
+                var odataDtos = botAgents.Select(MapToODataDto);
+                return Ok(odataDtos);
             }
             catch (Exception ex)
             {
@@ -131,8 +132,9 @@ namespace OpenAutomate.API.Controllers.OData
                 var botAgent = await _botAgentService.GetBotAgentByIdAsync(key);
                 if (botAgent == null)
                     return NotFound();
-                    
-                return Ok(botAgent);
+
+                var odataDto = MapToODataDto(botAgent);
+                return Ok(odataDto);
             }
             catch (Exception ex)
             {
@@ -140,5 +142,22 @@ namespace OpenAutomate.API.Controllers.OData
                 return StatusCode(500, "An error occurred while retrieving the bot agent");
             }
         }
+
+        /// <summary>
+        /// Maps a BotAgentResponseDto to a BotAgentODataDto, excluding sensitive information
+        /// </summary>
+        /// <param name="botAgent">The Bot Agent response DTO</param>
+        /// <returns>OData DTO without sensitive information</returns>
+        private static BotAgentODataDto MapToODataDto(BotAgentResponseDto botAgent)
+        {
+            return new BotAgentODataDto
+            {
+                Id = botAgent.Id,
+                Name = botAgent.Name,
+                MachineName = botAgent.MachineName,
+                Status = botAgent.Status,
+                IsActive = botAgent.IsActive
+            };
+        }
     }
-} 
+}

--- a/OpenAutomate.API/Extensions/ODataExtensions.cs
+++ b/OpenAutomate.API/Extensions/ODataExtensions.cs
@@ -26,7 +26,7 @@ namespace OpenAutomate.API.Extensions
             var builder = new ODataConventionModelBuilder();
             
             // Register entity sets based on DTOs
-            builder.EntitySet<BotAgentResponseDto>("BotAgents");
+            builder.EntitySet<BotAgentODataDto>("BotAgents");
             builder.EntitySet<UserResponse>("Users");
             builder.EntitySet<AssetResponseDto>("Assets");
             builder.EntitySet<AutomationPackageResponseDto>("AutomationPackages");

--- a/OpenAutomate.Core/Constants/Permissions.cs
+++ b/OpenAutomate.Core/Constants/Permissions.cs
@@ -23,14 +23,14 @@ namespace OpenAutomate.Core.Constants
         public const int Create = 2;
         
         /// <summary>
-        /// Update permission (3) - ability to modify existing resources and execute operations
-        /// Includes: View, Create, Execute
+        /// Update permission (3) - ability to modify existing resources
+        /// Includes: View, Create
         /// </summary>
         public const int Update = 3;
         
         /// <summary>
         /// Delete permission (4) - highest level with full administrative access including delete operations
-        /// Includes: View, Create, Update, Execute
+        /// Includes: View, Create, Update
         /// </summary>
         public const int Delete = 4;
         

--- a/OpenAutomate.Core/Constants/Resources.cs
+++ b/OpenAutomate.Core/Constants/Resources.cs
@@ -144,7 +144,7 @@ namespace OpenAutomate.Core.Constants
                 {
                     Level = Permissions.Update,
                     Name = "Update",
-                    Description = "View, create, and modify items (includes execute)"
+                    Description = "View, create, and modify items"
                 },
                 new PermissionLevelDto
                 {

--- a/OpenAutomate.Core/Dto/BotAgent/BotAgentODataDto.cs
+++ b/OpenAutomate.Core/Dto/BotAgent/BotAgentODataDto.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace OpenAutomate.Core.Dto.BotAgent
+{
+    /// <summary>
+    /// DTO for Bot Agent OData responses - excludes sensitive information like machine keys
+    /// </summary>
+    public class BotAgentODataDto
+    {
+        /// <summary>
+        /// Unique identifier for the Bot Agent
+        /// </summary>
+        public Guid Id { get; set; }
+        
+        /// <summary>
+        /// The display name for the Bot Agent
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+        
+        /// <summary>
+        /// The machine name of the computer where the Bot Agent runs
+        /// </summary>
+        public string MachineName { get; set; } = string.Empty;
+        
+        /// <summary>
+        /// Current status of the Bot Agent (Pending, Online, Offline, etc.)
+        /// </summary>
+        public string Status { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Whether the Bot Agent is active and allowed to connect
+        /// </summary>
+        public bool IsActive { get; set; }
+    }
+}


### PR DESCRIPTION
Introduced BotAgentODataDto to exclude sensitive information from OData responses. Updated BotAgentsController and OData model registration to use the new DTO. Improved permission error messages in RequirePermissionAttribute and clarified permission descriptions in constants.