### PR TITLE
Add Quartz job diagnostic and manual trigger endpoints

### DIFF
--- a/OpenAutomate.Core/IServices/IQuartzScheduleManager.cs
+++ b/OpenAutomate.Core/IServices/IQuartzScheduleManager.cs
@@ -52,10 +52,24 @@ namespace OpenAutomate.Core.IServices
         Task<bool> JobExistsAsync(Guid scheduleId);
 
         /// <summary>
+        /// Checks if a Quartz job is paused for a schedule
+        /// </summary>
+        /// <param name="scheduleId">Schedule ID</param>
+        /// <returns>True if job is paused, false otherwise</returns>
+        Task<bool> IsJobPausedAsync(Guid scheduleId);
+
+        /// <summary>
         /// Gets detailed status information about a scheduled job
         /// </summary>
         /// <param name="scheduleId">Schedule ID</param>
         /// <returns>Job status information or null if job doesn't exist</returns>
         Task<object?> GetJobStatusAsync(Guid scheduleId);
+
+        /// <summary>
+        /// Manually triggers a job for a schedule
+        /// </summary>
+        /// <param name="scheduleId">Schedule ID</param>
+        /// <returns>Task representing the async operation</returns>
+        Task TriggerJobAsync(Guid scheduleId);
     }
 } 


### PR DESCRIPTION
Introduces new endpoints in ScheduleController to check Quartz job status and manually trigger jobs for schedules. Updates IQuartzScheduleManager interface and QuartzScheduleManager implementation to support job status checks (paused state) and manual triggering. These changes improve diagnostics and testing capabilities for scheduled jobs.